### PR TITLE
Update GUI deps

### DIFF
--- a/docs/gui_setup.md
+++ b/docs/gui_setup.md
@@ -1,7 +1,9 @@
 # GUI Setup
 
 1. Install Node.js and npm.
-2. Navigate to `gui` folder and run `npm install` (requires internet).
+2. Navigate to `gui` folder and run `npm install` (requires internet). This installs
+   all dependencies including **ts-node**, which is required for starting
+   Electron from the TypeScript entry point.
 3. Launch development mode with `npm run start`.
 4. Build the desktop app with `npm run make`.
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,6 +31,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.0.0",
     "ts-jest": "^29.0.0",
+    "ts-node": "^10.0.0",
     "electron-builder": "^24.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ts-node dev dependency for Electron runtime
- document requirement for ts-node when installing GUI

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `pytest -q` *(fails: fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878082f9dc48332996b4b256086ae9d