### PR TITLE
Add basic RAG engine with CLI support

### DIFF
--- a/algorips/cli/main.py
+++ b/algorips/cli/main.py
@@ -9,6 +9,7 @@ from algorips.core.analyzer import CodeAnalyzer
 from algorips.core.git import local
 from algorips.core.git.github import GitHubClient
 from algorips.core.plugins import PluginManager
+from algorips.core.rag import RAGEngine
 
 DEFAULT_CONFIG = (
     "database:\n"
@@ -65,6 +66,18 @@ def apply_rule(rule_id: str, file_path: str) -> None:
         click.echo("Patch applied")
     else:
         click.echo("Failed to apply patch")
+
+
+@cli.command("rag")
+@click.argument("docs", nargs=-1, type=click.Path(exists=True))
+@click.option("--query", "query_text", required=True)
+def rag_cmd(docs: tuple[str, ...], query_text: str) -> None:
+    """Query documents using a simple RAG engine."""
+    engine = RAGEngine(docs, use_faiss=False)
+    engine.ingest()
+    results = engine.query(query_text)
+    for res in results:
+        click.echo(res)
 
 
 @cli.group()

--- a/algorips/core/rag.py
+++ b/algorips/core/rag.py
@@ -1,0 +1,160 @@
+"""Simple retrieval augmented generation utilities."""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Callable, Iterable, List, Tuple
+
+
+Vector = List[float]
+
+
+def _cosine_similarity(a: Vector, b: Vector) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na and nb:
+        return dot / (na * nb)
+    return 0.0
+
+
+class JSONVectorStore:
+    """Very small JSON based vector store."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.data: List[dict] = []
+        self.load()
+
+    def add(self, text: str, vector: Vector) -> None:
+        self.data.append({"text": text, "vector": vector})
+
+    def search(self, vector: Vector, top_k: int = 3) -> List[Tuple[str, float]]:
+        results = [
+            (item["text"], _cosine_similarity(vector, item["vector"]))
+            for item in self.data
+        ]
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:top_k]
+
+    def save(self) -> None:
+        with self.path.open("w") as f:
+            json.dump(self.data, f)
+
+    def load(self) -> None:
+        if self.path.exists():
+            self.data = json.loads(self.path.read_text())
+        else:
+            self.data = []
+
+
+try:  # optional faiss support
+    import faiss  # type: ignore
+    import numpy as np  # type: ignore
+
+    class FAISSVectorStore(JSONVectorStore):
+        def __init__(self, path: str | Path, dim: int) -> None:
+            self.index_path = Path(path).with_suffix(".index")
+            super().__init__(Path(path).with_suffix(".json"))
+            self.dim = dim
+            if self.index_path.exists():
+                self.index = faiss.read_index(str(self.index_path))
+            else:
+                self.index = faiss.IndexFlatL2(dim)
+
+        def add(self, text: str, vector: Vector) -> None:
+            import numpy as np
+
+            v = np.array(vector, dtype="float32").reshape(1, -1)
+            self.index.add(v)
+            self.data.append({"text": text, "vector": vector})
+
+        def search(self, vector: Vector, top_k: int = 3) -> List[Tuple[str, float]]:
+            import numpy as np
+
+            v = np.array(vector, dtype="float32").reshape(1, -1)
+            D, I = self.index.search(v, top_k)
+            results = []
+            for idx, dist in zip(I[0], D[0]):
+                if idx == -1:
+                    continue
+                text = self.data[int(idx)]["text"]
+                results.append((text, float(-dist)))
+            results.sort(key=lambda x: x[1], reverse=True)
+            return results
+
+        def save(self) -> None:
+            super().save()
+            faiss.write_index(self.index, str(self.index_path))
+
+except Exception:  # pragma: no cover - faiss not available
+    FAISSVectorStore = None  # type: ignore
+
+
+class RAGEngine:
+    """Load documents, embed them and perform simple retrieval."""
+
+    def __init__(
+        self,
+        docs: Iterable[str | Path],
+        store_path: str | Path | None = None,
+        embed_fn: Callable[[str], Vector] | None = None,
+        use_faiss: bool = True,
+    ) -> None:
+        self.docs = [Path(d) for d in docs]
+        self.embed_fn = embed_fn or self._default_embed
+        store = store_path or "rag_store.json"
+        self.use_faiss = use_faiss and FAISSVectorStore is not None
+        self.store_path = Path(store)
+        self.store: JSONVectorStore | FAISSVectorStore
+        if self.use_faiss:
+            # dim will be determined on first embed
+            self.store = FAISSVectorStore(self.store_path, 0)  # type: ignore[arg-type]
+        else:
+            self.store = JSONVectorStore(self.store_path)
+
+    def _default_embed(self, text: str) -> Vector:
+        return [float(ord(c)) for c in text][:32]
+
+    @staticmethod
+    def _read_text(path: Path) -> str:
+        if path.suffix.lower() == ".pdf":
+            try:
+                from pdfminer.high_level import extract_text  # type: ignore
+
+                return extract_text(str(path))
+            except Exception:
+                return ""
+        return path.read_text(encoding="utf-8")
+
+    def ingest(self) -> None:
+        texts: List[str] = []
+        for doc in self.docs:
+            if not doc.exists():
+                continue
+            text = self._read_text(doc)
+            for line in text.splitlines():
+                line = line.strip()
+                if line:
+                    texts.append(line)
+        if not texts:
+            return
+        embeddings = [self.embed_fn(t) for t in texts]
+        if self.use_faiss:
+            # recreate index with correct dimension if needed
+            dim = len(embeddings[0])
+            self.store = FAISSVectorStore(self.store_path, dim)  # type: ignore[arg-type]
+        for text, vec in zip(texts, embeddings):
+            self.store.add(text, vec)
+        self.store.save()
+
+    def query(self, text: str, top_k: int = 3) -> List[str]:
+        if not getattr(self.store, "data", None):
+            # try load
+            self.store.load()
+        vec = self.embed_fn(text)
+        results = self.store.search(vec, top_k)
+        return [t for t, _ in results]

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,8 @@
 import sys
 from pathlib import Path
+import time
+import types
+import pytest
 
 class _CoverageTracer:
     def __init__(self):
@@ -47,3 +50,20 @@ def pytest_sessionfinish(session, exitstatus):
     print(f'Coverage: {percent:.1f}%')
     if percent < 80.0:
         session.exitstatus = 1
+
+
+class _SimpleBenchmark:
+    def __init__(self):
+        self.stats = types.SimpleNamespace(stats={"mean": 0.0})
+
+    def __call__(self, func, *args, **kwargs):
+        start = time.time()
+        result = func(*args, **kwargs)
+        end = time.time()
+        self.stats.stats["mean"] = end - start
+        return result
+
+
+@pytest.fixture
+def benchmark():
+    return _SimpleBenchmark()

--- a/plugins/rag_markdown/__init__.py
+++ b/plugins/rag_markdown/__init__.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
+import click
+
 from algorips.core.plugins.contract import BasePlugin
+from algorips.core.rag import RAGEngine
+
 
 class Plugin(BasePlugin):
     def name(self) -> str:
@@ -10,5 +16,11 @@ class Plugin(BasePlugin):
     def register(self, cli, gui_registry) -> None:
         if cli:
             @cli.command("rag-md")
-            def rag_md() -> None:
-                print("RAG Markdown")
+            @click.argument("docs", nargs=-1, type=click.Path(exists=True))
+            @click.option("--query", "query_text", required=True)
+            def rag_md(docs: tuple[str, ...], query_text: str) -> None:
+                engine = RAGEngine(docs, use_faiss=False)
+                engine.ingest()
+                results = engine.query(query_text)
+                for res in results:
+                    click.echo(res)

--- a/tests/rag/test_rag_engine.py
+++ b/tests/rag/test_rag_engine.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from algorips.core.rag import RAGEngine
+
+
+def test_ingest_creates_store(tmp_path: Path):
+    doc = tmp_path / "d1.txt"
+    doc.write_text("hello world")
+
+    engine = RAGEngine([doc], store_path=tmp_path / "store.json", embed_fn=lambda t: [1.0])
+    engine.ingest()
+
+    store_file = tmp_path / "store.json"
+    assert store_file.exists()
+    data = store_file.read_text()
+    assert "hello world" in data
+
+
+def test_query_returns_expected(tmp_path: Path):
+    d1 = tmp_path / "a.txt"
+    d2 = tmp_path / "b.txt"
+    d1.write_text("alpha")
+    d2.write_text("beta")
+
+    def fake_embed(text: str):
+        mapping = {
+            "alpha": [1.0, 0.0],
+            "beta": [0.0, 1.0],
+            "query": [1.0, 0.0],
+        }
+        return mapping.get(text.strip(), [0.0, 0.0])
+
+    engine = RAGEngine([d1, d2], store_path=tmp_path / "store.json", embed_fn=fake_embed)
+    engine.ingest()
+
+    results = engine.query("query")
+    assert results and results[0] == "alpha"


### PR DESCRIPTION
## Summary
- implement simple retrieval engine `RAGEngine` with optional FAISS backend
- expose `rag` command in CLI
- update rag_markdown plugin to use the new engine
- provide tests for document ingestion and querying
- add benchmark fixture fallback for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781f1404808332af7ced5e632230f7