### PR TITLE
Add metrics page

### DIFF
--- a/gui/index.tsx
+++ b/gui/index.tsx
@@ -6,6 +6,7 @@ import Home from './src/features/home/Home';
 import Analyze from './src/features/analyze/Analyze';
 import Repository from './src/features/repository/Repository';
 import Plugins from './src/features/plugins/Plugins';
+import Metrics from './src/features/metrics/Metrics';
 import { useAppStore } from './src/store';
 
 const RootApp: React.FC = () => {
@@ -15,6 +16,7 @@ const RootApp: React.FC = () => {
       {projectPath ? <Analyze /> : <Home />}
       <Repository />
       <Plugins />
+      <Metrics />
     </Layout>
   );
 };

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layers, Wand2, FlaskConical, Plug } from 'lucide-react';
+import { Layers, Wand2, FlaskConical, Plug, BarChart2 } from 'lucide-react';
 
 const Sidebar: React.FC = () => (
   <nav className="sidebar">
@@ -8,6 +8,7 @@ const Sidebar: React.FC = () => (
       <li><Wand2 size={20}/> Refactor</li>
       <li><FlaskConical size={20}/> Tests</li>
       <li><Plug size={20}/> Plugins</li>
+      <li><BarChart2 size={20}/> Metrics</li>
     </ul>
   </nav>
 );

--- a/gui/src/features/metrics/Metrics.tsx
+++ b/gui/src/features/metrics/Metrics.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+
+interface MetricPoint {
+  name: string;
+  value: number;
+}
+
+const Metrics: React.FC = () => {
+  const [data, setData] = useState<MetricPoint[]>([]);
+
+  const fetchMetrics = async () => {
+    try {
+      const res = await fetch('/metrics');
+      const text = await res.text();
+      const counters: MetricPoint[] = [];
+      text.split('\n').forEach(line => {
+        if (line.startsWith('#')) return;
+        const [key, val] = line.split(' ');
+        if (key && val && key.endsWith('_total')) {
+          counters.push({ name: key, value: parseFloat(val) });
+        }
+      });
+      setData(counters);
+    } catch (err) {
+      console.error('Failed to load metrics', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchMetrics();
+    const id = setInterval(fetchMetrics, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div>
+      <h2>Metrics</h2>
+      <LineChart width={400} height={200} data={data} aria-label="Metrics chart">
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis allowDecimals={false} />
+        <Tooltip />
+        <Line type="monotone" dataKey="value" stroke="#8884d8" />
+      </LineChart>
+    </div>
+  );
+};
+
+export default Metrics;

--- a/monitoring/grafana/dashboard.json
+++ b/monitoring/grafana/dashboard.json
@@ -1,3 +1,22 @@
 {
-  "dashboard": "placeholder"
+  "dashboard": {
+    "title": "AlgoriPS Metrics",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "Requests",
+        "targets": [
+          { "expr": "algorips_requests_total", "legendFormat": "requests" }
+        ]
+      },
+      {
+        "type": "graph",
+        "title": "Analyses",
+        "targets": [
+          { "expr": "algorips_analysis_total", "legendFormat": "analysis count" }
+        ]
+      }
+    ]
+  }
 }
+

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -2,6 +2,7 @@ global:
   scrape_interval: 15s
 scrape_configs:
   - job_name: 'algorips'
+    metrics_path: /metrics
     static_configs:
       - targets: ['algorips:8000']
 alerting:


### PR DESCRIPTION
## Summary
- fetch `/metrics` in a new Metrics component and visualize counters with Recharts
- show Metrics link in the sidebar
- include Metrics page in the GUI layout
- expose `/metrics` path to Prometheus
- reference basic counters in Grafana dashboard

## Testing
- `pytest -q` *(fails: fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781f1499088332a9e58a05e5c1664e