### PR TITLE
Enhance plugin manager with metadata and persistence

### DIFF
--- a/algorips/core/plugins/contract.py
+++ b/algorips/core/plugins/contract.py
@@ -33,6 +33,11 @@ class BasePlugin(ABC):
         """
 
     @property
+    def description(self) -> str:
+        """Short summary of what the plugin provides."""
+        return ""
+
+    @property
     def dependencies(self) -> list[str]:
         """List optional external dependencies required by the plugin."""
         return []

--- a/plugins/eslint_plugin/__init__.py
+++ b/plugins/eslint_plugin/__init__.py
@@ -7,6 +7,14 @@ class Plugin(BasePlugin):
     def version(self) -> str:
         return "0.1"
 
+    @property
+    def description(self) -> str:
+        return "Run ESLint on JavaScript/TypeScript code"
+
+    @property
+    def dependencies(self) -> list[str]:
+        return []
+
     def register(self, cli, gui_registry) -> None:
         if cli:
             @cli.command("eslint-run")

--- a/plugins/rag_markdown/__init__.py
+++ b/plugins/rag_markdown/__init__.py
@@ -7,6 +7,14 @@ class Plugin(BasePlugin):
     def version(self) -> str:
         return "0.1"
 
+    @property
+    def description(self) -> str:
+        return "Retrieval-Augmented Generation for Markdown"
+
+    @property
+    def dependencies(self) -> list[str]:
+        return []
+
     def register(self, cli, gui_registry) -> None:
         if cli:
             @cli.command("rag-md")

--- a/plugins/ts_analyzer/__init__.py
+++ b/plugins/ts_analyzer/__init__.py
@@ -7,6 +7,14 @@ class Plugin(BasePlugin):
     def version(self) -> str:
         return "0.1"
 
+    @property
+    def description(self) -> str:
+        return "Analyze TypeScript projects"
+
+    @property
+    def dependencies(self) -> list[str]:
+        return []
+
     def register(self, cli, gui_registry) -> None:
         if cli:
             @cli.command("ts-check")

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from algorips.core.plugins.manager import PluginManager
 from algorips.core.plugins.contract import BasePlugin
+from importlib import metadata
 
 
 class DummyPlugin(BasePlugin):
@@ -16,6 +17,14 @@ class DummyPlugin(BasePlugin):
             cli.called = True
         if gui_registry is not None:
             gui_registry.append("dummy")
+
+    @property
+    def description(self) -> str:
+        return "Dummy plugin"
+
+    @property
+    def dependencies(self) -> list[str]:
+        return []
 
 
 def create_plugin(path: Path) -> None:
@@ -57,3 +66,39 @@ def test_install_uninstall(tmp_path: Path):
     assert (plugin_dir / "src").exists()
     mgr.uninstall("src")
     assert not (plugin_dir / "src").exists()
+
+
+def test_list_metadata(tmp_path: Path):
+    create_plugin(tmp_path)
+    mgr = PluginManager(plugin_dir=tmp_path)
+    mgr.discover()
+    info = next(iter(mgr.list_plugins()))
+    assert info["description"] == "Dummy plugin"
+    assert info["dependencies"] == []
+
+
+def test_persistent_activation(tmp_path: Path):
+    create_plugin(tmp_path)
+    mgr = PluginManager(plugin_dir=tmp_path)
+    mgr.discover()
+    mgr.activate("dummy")
+    assert (tmp_path / "active.json").exists()
+    mgr2 = PluginManager(plugin_dir=tmp_path)
+    assert "dummy" in mgr2._active
+
+
+def test_entry_point_loading(tmp_path: Path, monkeypatch):
+    class EP:
+        def load(self):
+            return DummyPlugin
+
+    class EPS(list):
+        def select(self, **kwargs):
+            if kwargs.get("group") == "algorips.plugins":
+                return [EP()]
+            return []
+
+    monkeypatch.setattr(metadata, "entry_points", lambda: EPS())
+    mgr = PluginManager(plugin_dir=tmp_path)
+    plugins = mgr.discover()
+    assert "dummy" in plugins


### PR DESCRIPTION
## Summary
- extend `BasePlugin` with a `description` property
- persist active plugins to disk and support entry point discovery
- expose plugin metadata from `PluginManager.list_plugins`
- update example plugins to define descriptions
- expand plugin manager tests for metadata, persistence and entry points

## Testing
- `pytest -q` *(fails: fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781f1510b88332876cd057b309d2d0