### PR TITLE
Add Chat UI with streaming and backend support

### DIFF
--- a/algorips/core/server.py
+++ b/algorips/core/server.py
@@ -2,11 +2,13 @@ from flask import Flask, Response, jsonify, request
 from prometheus_client import generate_latest, Counter, Summary
 import time
 from .analyzer import CodeAnalyzer
+from .ollama_client import OllamaClient
 
 app = Flask(__name__)
 REQUESTS = Counter('algorips_requests_total', 'Total requests')
 ANALYSIS_COUNT = Counter('algorips_analysis_total', 'Total analyses')
 ANALYSIS_LATENCY = Summary('algorips_analysis_latency_seconds', 'Analysis latency seconds')
+client = OllamaClient()
 
 @app.route('/healthz')
 def healthz():
@@ -27,6 +29,15 @@ def analyze_route():
     duration = time.perf_counter() - start
     ANALYSIS_COUNT.inc()
     ANALYSIS_LATENCY.observe(duration)
+    return jsonify(result)
+
+
+@app.route('/chat', methods=['POST'])
+def chat_route():
+    """Forward chat prompts to the Ollama client."""
+    data = request.get_json() or {}
+    prompt = data.get('prompt', '')
+    result = client.send_prompt(prompt)
     return jsonify(result)
 
 if __name__ == '__main__':

--- a/gui/index.tsx
+++ b/gui/index.tsx
@@ -6,6 +6,7 @@ import Home from './src/features/home/Home';
 import Analyze from './src/features/analyze/Analyze';
 import Repository from './src/features/repository/Repository';
 import Plugins from './src/features/plugins/Plugins';
+import Chat from './src/features/chat/Chat';
 import { useAppStore } from './src/store';
 
 const RootApp: React.FC = () => {
@@ -15,6 +16,7 @@ const RootApp: React.FC = () => {
       {projectPath ? <Analyze /> : <Home />}
       <Repository />
       <Plugins />
+      <Chat />
     </Layout>
   );
 };

--- a/gui/src/__tests__/Chat.test.tsx
+++ b/gui/src/__tests__/Chat.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Chat from '../features/chat/Chat';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders chat input', () => {
+  const { getByLabelText, getByText } = render(<Chat />);
+  expect(getByLabelText('prompt')).toBeInTheDocument();
+  expect(getByText('Send')).toBeInTheDocument();
+});
+
+test('sends prompt to backend', async () => {
+  const fakeReader = { read: jest.fn().mockResolvedValue({ done: true }) };
+  global.fetch = jest.fn().mockResolvedValue({ body: { getReader: () => fakeReader } } as any);
+
+  const { getByLabelText, getByText } = render(<Chat />);
+  fireEvent.change(getByLabelText('prompt'), { target: { value: 'hello' } });
+  fireEvent.click(getByText('Send'));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  expect((fetch as jest.Mock).mock.calls[0][0]).toBe('/chat');
+});

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -58,3 +58,16 @@ export async function installPlugin(path: string): Promise<void> {
 export async function uninstallPlugin(name: string): Promise<void> {
   console.log('uninstallPlugin', name);
 }
+
+export async function chatWithOllama(prompt: string, db: string): Promise<ReadableStreamDefaultReader<Uint8Array>> {
+  const res = await fetch('/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt, db }),
+  });
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error('Streaming not supported');
+  }
+  return reader;
+}


### PR DESCRIPTION
## Summary
- add new Chat React component with streaming and IndexedDB history
- expose `/chat` endpoint to forward prompts to OllamaClient
- extend API utilities with `chatWithOllama`
- integrate Chat page into Electron app
- add Jest tests for Chat component

## Testing
- `pytest -q` *(fails: benchmark fixture missing)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781f18a57c8332b91aba09b9bb76aa