### PR TITLE
Add jest-dom setup in gui tests

### DIFF
--- a/gui/jest.config.js
+++ b/gui/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   roots: ['<rootDir>/src'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest'

--- a/gui/jest.setup.ts
+++ b/gui/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/gui/src/__tests__/Chat.test.tsx
+++ b/gui/src/__tests__/Chat.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import Chat from '../features/chat/Chat';

--- a/gui/src/__tests__/Sidebar.test.tsx
+++ b/gui/src/__tests__/Sidebar.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import React from 'react';
 import { render } from '@testing-library/react';
 import Sidebar from '../components/Sidebar';


### PR DESCRIPTION
## Summary
- register jest-dom setup in GUI jest config
- create `jest.setup.ts`
- import jest-dom at top of Chat and Sidebar tests

## Testing
- `pytest -q`
- `npx jest --runInBand` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68782d0e05fc8332ab757948fad659db