### PR TITLE
Fix GUI start without ts-node

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -1,2 +1,14 @@
-require('ts-node/register');
-require('./electron.ts');
+const fs = require('fs');
+const path = require('path');
+
+// Attempt to use the compiled JavaScript build first. This avoids
+// requiring ts-node during runtime when dependencies are not installed.
+const compiled = path.join(__dirname, 'dist', 'electron.js');
+
+if (fs.existsSync(compiled)) {
+  require(compiled);
+} else {
+  // Fallback to executing the TypeScript source via ts-node.
+  require('ts-node/register');
+  require('./electron.ts');
+}


### PR DESCRIPTION
## Summary
- prevent runtime crash when `ts-node` isn't installed
- use the compiled electron build if available

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687831f7b5588332a5106d33a5f07eb3