### PR TITLE
Fix GUI build failing on tests

### DIFF
--- a/gui/electron.ts
+++ b/gui/electron.ts
@@ -14,8 +14,8 @@ function createWindow() {
   if (process.env.NODE_ENV === 'development') {
     win.loadURL('http://localhost:3000');
   } else {
-    const devPath = path.join(__dirname, 'public', 'index.html');
-    const prodPath = path.join(__dirname, '..', 'public', 'index.html');
+    const devPath = path.join(__dirname, 'dist', 'index.html');
+    const prodPath = path.join(__dirname, '..', 'dist', 'index.html');
     const target = fs.existsSync(devPath) ? devPath : prodPath;
     win.loadFile(target);
   }

--- a/gui/main.js
+++ b/gui/main.js
@@ -1,2 +1,14 @@
-require('ts-node/register');
-require('./electron.ts');
+const fs = require('fs');
+const path = require('path');
+
+// Attempt to use the compiled JavaScript build first. This avoids
+// requiring ts-node during runtime when dependencies are not installed.
+const compiled = path.join(__dirname, 'dist', 'electron.js');
+
+if (fs.existsSync(compiled)) {
+  require(compiled);
+} else {
+  // Fallback to executing the TypeScript source via ts-node.
+  require('ts-node/register');
+  require('./electron.ts');
+}

--- a/gui/package.json
+++ b/gui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "start": "npm run build && electron .",
-    "build": "tsc",
+    "build": "tsc && webpack --config webpack.config.js",
     "make": "electron-builder"
   },
   "keywords": [],
@@ -33,6 +33,11 @@
     "@types/jest": "^29.0.0",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.0.0",
-    "electron-builder": "^24.0.0"
+    "electron-builder": "^24.0.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "html-webpack-plugin": "^5.5.0",
+    "webpack": "^5.90.0",
+    "webpack-cli": "^5.0.0",
+    "ts-loader": "^9.5.0"
   }
 }

--- a/gui/public/index.html
+++ b/gui/public/index.html
@@ -6,6 +6,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="../dist/index.js"></script>
   </body>
 </html>

--- a/gui/tsconfig.json
+++ b/gui/tsconfig.json
@@ -9,5 +9,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*", "electron.ts", "index.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__"]
 }

--- a/gui/webpack.config.js
+++ b/gui/webpack.config.js
@@ -1,0 +1,32 @@
+// Configure Webpack to bundle the renderer React code.
+// This replaces the old loader reference to
+// `html-webpack-plugin/lib/loader.js` and uses the plugin directly.
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  mode: 'development',
+  entry: path.resolve(__dirname, 'index.tsx'),
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'renderer.js'
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: 'ts-loader'
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, 'public', 'index.html'),
+      filename: 'index.html'
+    })
+  ]
+};


### PR DESCRIPTION
## Summary
- add @testing-library/jest-dom as dev dependency
- skip test files when compiling the GUI
- add Webpack build with HtmlWebpackPlugin for the GUI
- adjust Electron to load the bundled index

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687831f7b5588332a5106d33a5f07eb3