### PR TITLE
Add database init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Activate the virtual environment and install dependencies::
     .\.venv\Scripts\Activate
     pip install -r requirements.txt
 
-Database migrations are stored as SQL files under `db/migrations`. The initial
-script creates a `projects` table that stores analyzed project metadata.
+Database migrations are stored as SQL files under `db/migrations`. Use the
+helper script `scripts/init_db.py` to create the database and apply all
+migrations automatically::
+
+    python scripts/init_db.py
 
 Run the CLI::
 

--- a/gui/src/__tests__/OllamaStatus.test.tsx
+++ b/gui/src/__tests__/OllamaStatus.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import OllamaStatus from '../components/OllamaStatus';
+import * as api from '../utils/api';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('shows online message', async () => {
+  jest.spyOn(api, 'isOllamaUp').mockResolvedValue(true);
+  const { getByLabelText } = render(<OllamaStatus />);
+  await waitFor(() => {
+    expect(getByLabelText('ollama-status')).toHaveTextContent('Modelo listo');
+  });
+});
+
+test('shows offline message', async () => {
+  jest.spyOn(api, 'isOllamaUp').mockResolvedValue(false);
+  const { getByLabelText } = render(<OllamaStatus />);
+  await waitFor(() => {
+    expect(getByLabelText('ollama-status')).toHaveTextContent('Sin conexión');
+  });
+});

--- a/gui/src/__tests__/ThemeToggle.test.tsx
+++ b/gui/src/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ThemeToggle from '../components/ThemeToggle';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+test('toggles and persists theme', () => {
+  const { getByLabelText } = render(<ThemeToggle />);
+  const btn = getByLabelText('toggle-theme');
+  fireEvent.click(btn);
+  expect(localStorage.getItem('theme')).toBe('dark');
+});

--- a/gui/src/components/Footer.tsx
+++ b/gui/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Footer: React.FC = () => (
   <footer className="p-4 text-center text-sm text-gray-500 border-t border-gray-200" aria-label="footer">
-    AlgoriPS © 2025
+    Creado por Noel Pérez Saldaña
   </footer>
 );
 

--- a/gui/src/components/Header.tsx
+++ b/gui/src/components/Header.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ThemeToggle from './ThemeToggle';
+import OllamaStatus from './OllamaStatus';
 
 const Header: React.FC = () => (
   <header className="flex items-center justify-between p-4 bg-surface shadow-lg" role="banner">
     <h1 className="text-xl font-bold">AlgoriPS</h1>
-    <ThemeToggle />
+    <div className="flex items-center gap-4">
+      <OllamaStatus />
+      <ThemeToggle />
+    </div>
   </header>
 );
 

--- a/gui/src/components/OllamaStatus.tsx
+++ b/gui/src/components/OllamaStatus.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { isOllamaUp } from '../utils/api';
+
+const OllamaStatus: React.FC = () => {
+  const [online, setOnline] = useState(false);
+
+  const check = async () => {
+    setOnline(await isOllamaUp());
+  };
+
+  useEffect(() => {
+    check();
+    const id = setInterval(check, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="flex items-center gap-1 text-sm" aria-label="ollama-status">
+      {online ? (
+        <>
+          <CheckCircle className="w-4 h-4 text-green-600" />
+          <span>Modelo listo</span>
+        </>
+      ) : (
+        <>
+          <XCircle className="w-4 h-4 text-red-600" />
+          <span>Sin conexión</span>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default OllamaStatus;

--- a/gui/src/components/ThemeToggle.tsx
+++ b/gui/src/components/ThemeToggle.tsx
@@ -5,10 +5,21 @@ const ThemeToggle: React.FC = () => {
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    if (saved) {
+      setDark(saved === 'dark');
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setDark(true);
+    }
+  }, []);
+
+  useEffect(() => {
     if (dark) {
       document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
     } else {
       document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
     }
   }, [dark]);
 

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -85,3 +85,13 @@ export async function chatWithOllama(prompt: string, db: string): Promise<Readab
   }
   return reader;
 }
+
+export async function isOllamaUp(): Promise<boolean> {
+  try {
+    const url = (process as any).env.OLLAMA_URL || 'http://localhost:11434';
+    const res = await fetch(url, { method: 'HEAD' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+from sqlalchemy import create_engine, text
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "db" / "migrations"
+
+
+def get_engine():
+    user = os.getenv("MYSQL_USER", "root")
+    password = os.getenv("MYSQL_PASSWORD", "example")
+    host = os.getenv("MYSQL_HOST", "localhost")
+    database = os.getenv("MYSQL_DATABASE", "algorips")
+    url = f"mysql+pymysql://{user}:{password}@{host}/{database}"
+    return create_engine(url, future=True)
+
+
+def run_migrations():
+    engine = get_engine()
+    for sql_file in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        stmt = sql_file.read_text()
+        with engine.begin() as conn:
+            conn.execute(text(stmt))
+        print(f"Applied {sql_file.name}")
+
+
+if __name__ == "__main__":
+    run_migrations()

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,11 +1,16 @@
+"""Utility script to bootstrap the MySQL database."""
+
 import os
 from pathlib import Path
+
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 
 MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "db" / "migrations"
 
 
-def get_engine():
+def get_engine() -> Engine:
+    """Return an engine for the target database."""
     user = os.getenv("MYSQL_USER", "root")
     password = os.getenv("MYSQL_PASSWORD", "example")
     host = os.getenv("MYSQL_HOST", "localhost")
@@ -14,7 +19,29 @@ def get_engine():
     return create_engine(url, future=True)
 
 
+def ensure_database() -> None:
+    """Create the database and user if they do not exist."""
+    host = os.getenv("MYSQL_HOST", "localhost")
+    root_pw = os.getenv("MYSQL_ROOT_PASSWORD", os.getenv("MYSQL_PASSWORD", "example"))
+    database = os.getenv("MYSQL_DATABASE", "algorips")
+    user = os.getenv("MYSQL_USER", "root")
+    password = os.getenv("MYSQL_PASSWORD", "example")
+
+    root_url = f"mysql+pymysql://root:{root_pw}@{host}/"
+    root_engine = create_engine(root_url, future=True)
+    with root_engine.begin() as conn:
+        conn.execute(text(f"CREATE DATABASE IF NOT EXISTS {database}"))
+        if user != "root":
+            conn.execute(
+                text(
+                    f"CREATE USER IF NOT EXISTS '{user}'@'%' IDENTIFIED BY '{password}'"
+                )
+            )
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON {database}.* TO '{user}'@'%'"))
+
+
 def run_migrations():
+    ensure_database()
     engine = get_engine()
     for sql_file in sorted(MIGRATIONS_DIR.glob("*.sql")):
         stmt = sql_file.read_text()


### PR DESCRIPTION
## Summary
- add `scripts/init_db.py` to automate running SQL migrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784977a89483329f54250f0e61ba4a