### PR TITLE
Improve DB connector error handling

### DIFF
--- a/sqlalchemy/exc.py
+++ b/sqlalchemy/exc.py
@@ -1,0 +1,4 @@
+class SQLAlchemyError(Exception):
+    """Base SQLAlchemy error used for stubbed exceptions."""
+    pass
+


### PR DESCRIPTION
## Summary
- handle SQLAlchemy errors in `execute_query`
- add stub `sqlalchemy.exc` with `SQLAlchemyError`
- test error handling in db connector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788b26cea88332b1590b499e12c645