### PR TITLE
Use PyYAML as primary scraper loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,18 @@ Clone and manage repositories::
     python -m algorips repo commit "add feature"
     python -m algorips repo pr create --owner user --repo repo --token TOKEN "My PR"
     python -m algorips repo pr merge 1 --owner user --repo repo --token TOKEN
+
+## Web Scraper Configuration
+
+The ``scrape`` command reads a YAML file describing targets::
+
+    targets:
+      - url: http://example.com
+        selectors:
+          title: h1
+          heading: div.wrapper h1
+
+PyYAML is used to parse this configuration. If PyYAML is not available, the
+built-in fallback parser only understands the structure above and does not
+support nested mappings or complex YAML features. Nested selectors therefore
+require PyYAML.

--- a/algorips/core/scraper.py
+++ b/algorips/core/scraper.py
@@ -14,6 +14,11 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - not installed
     _requests = None
 
+try:  # main YAML parser
+    import yaml as _yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback parser only
+    _yaml = None
+
 
 @dataclass
 class ScrapeTarget:
@@ -31,6 +36,13 @@ class ScrapeConfig:
 
 
 def _simple_yaml_load(text: str) -> Dict[str, Any]:
+    """Tiny fallback YAML parser.
+
+    Only understands the ``targets`` structure used by the scraper and does not
+    support nested mappings or advanced YAML features. Use PyYAML whenever
+    possible.
+    """
+
     data: Dict[str, Any] = {}
     lines = [line.rstrip() for line in text.splitlines() if line.strip()]
     i = 0
@@ -60,14 +72,20 @@ def _simple_yaml_load(text: str) -> Dict[str, Any]:
 
 
 def load_config(path: str | Path) -> ScrapeConfig:
-    """Load YAML configuration from *path* without external dependencies."""
+    """Load YAML configuration from *path*.
+
+    PyYAML is used when available. If it cannot be imported, a minimal fallback
+    parser is used which only understands the ``targets`` list with ``url`` and
+    ``selectors``. Nested structures will not be parsed in that mode.
+    """
 
     text = Path(path).read_text()
-    try:  # Use PyYAML if available
-        import yaml as _yaml  # type: ignore
-
-        data = _yaml.safe_load(text)
-    except Exception:  # pragma: no cover - fallback parser
+    if _yaml is not None:
+        try:
+            data = _yaml.safe_load(text)
+        except Exception as exc:  # pragma: no cover - invalid YAML
+            raise ValueError(f"Invalid YAML: {exc}") from exc
+    else:  # pragma: no cover - fallback parser path
         data = _simple_yaml_load(text)
     targets = [
         ScrapeTarget(t["url"], t.get("selectors", {})) for t in data.get("targets", [])
@@ -98,22 +116,42 @@ class WebScraper:
                     super().__init__()
                     self.capture = False
                     self.text_parts: List[str] = []
+                    self.stack: List[tuple[str, List[str]]] = []
+                    self.path = [self._split(s) for s in selector.split()]
+
+                @staticmethod
+                def _split(token: str) -> tuple[str, str | None]:
+                    if "." in token:
+                        return token.split(".", 1)[0], token.split(".", 1)[1]
+                    return token, None
+
+                def _matches(self) -> bool:
+                    if len(self.stack) < len(self.path):
+                        return False
+                    for (tag, classes), (sel_tag, sel_cls) in zip(
+                        self.stack[-len(self.path) :], self.path
+                    ):
+                        if tag != sel_tag:
+                            return False
+                        if sel_cls and sel_cls not in classes:
+                            return False
+                    return True
 
                 def handle_starttag(self, tag, attrs):
                     cls = None
                     for n, v in attrs:
                         if n == "class":
                             cls = v
-                    if "." in selector:
-                        sel_tag, sel_cls = selector.split(".", 1)
-                    else:
-                        sel_tag, sel_cls = selector, None
-                    if tag == sel_tag and (sel_cls is None or (cls and sel_cls in cls.split())):
+                    classes = cls.split() if cls else []
+                    self.stack.append((tag, classes))
+                    if self._matches():
                         self.capture = True
 
                 def handle_endtag(self, tag):
-                    if self.capture and tag == selector.split(".")[0]:
+                    if self.capture and len(self.stack) == len(self.path) and tag == self.path[-1][0]:
                         self.capture = False
+                    if self.stack:
+                        self.stack.pop()
 
                 def handle_data(self, data):
                     if self.capture:

--- a/tests/scraper/test_scraper.py
+++ b/tests/scraper/test_scraper.py
@@ -34,3 +34,20 @@ def test_scrape(monkeypatch):
     result = scraper.scrape()
     assert result == [{"url": "http://example.com", "data": {"title": "Hello"}}]
 
+
+def test_scrape_nested_selectors(monkeypatch):
+    html = "<html><body><div class='wrapper'><h1>Hello</h1></div></body></html>"
+
+    def fake_fetch(self, url: str) -> str:  # type: ignore
+        return html
+
+    monkeypatch.setattr(WebScraper, "fetch", fake_fetch)
+    config = ScrapeConfig(
+        [ScrapeTarget("http://example.com", {"title": "div.wrapper h1"})]
+    )
+    scraper = WebScraper(config)
+    result = scraper.scrape()
+    assert result == [
+        {"url": "http://example.com", "data": {"title": "Hello"}}
+    ]
+


### PR DESCRIPTION
## Summary
- load scraper config with PyYAML when available
- keep simple fallback YAML parser with docs
- support nested selectors in `WebScraper`
- document scraper config and limitations
- test nested selectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788b2abc2c8332bf01350d006b89c3