### PR TITLE
Add metrics parser utility and tests

### DIFF
--- a/gui/src/__tests__/Metrics.test.tsx
+++ b/gui/src/__tests__/Metrics.test.tsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import Metrics from '../features/metrics/Metrics';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('shows error when metrics cannot be parsed', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    text: () => Promise.resolve('bad line')
+  }) as any;
+
+  const { getByRole } = render(<Metrics />);
+  await waitFor(() => {
+    expect(getByRole('alert')).toHaveTextContent('Could not parse metrics');
+  });
+});
+

--- a/gui/src/features/metrics/Metrics.tsx
+++ b/gui/src/features/metrics/Metrics.tsx
@@ -1,29 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
-
-interface MetricPoint {
-  name: string;
-  value: number;
-}
+import parseMetrics, { MetricPoint } from '../../utils/metricsParser';
 
 const Metrics: React.FC = () => {
   const [data, setData] = useState<MetricPoint[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchMetrics = async () => {
     try {
       const res = await fetch('/metrics');
       const text = await res.text();
-      const counters: MetricPoint[] = [];
-      text.split('\n').forEach(line => {
-        if (line.startsWith('#')) return;
-        const [key, val] = line.split(' ');
-        if (key && val && key.endsWith('_total')) {
-          counters.push({ name: key, value: parseFloat(val) });
-        }
-      });
+      const counters = parseMetrics(text);
       setData(counters);
+      setError(null);
     } catch (err) {
       console.error('Failed to load metrics', err);
+      setError('Could not parse metrics');
     }
   };
 
@@ -36,6 +28,11 @@ const Metrics: React.FC = () => {
   return (
     <div>
       <h2>Metrics</h2>
+      {error && (
+        <div role="alert" style={{ color: 'red' }}>
+          {error}
+        </div>
+      )}
       <LineChart width={400} height={200} data={data} aria-label="Metrics chart">
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="name" />

--- a/gui/src/utils/__tests__/metricsParser.test.ts
+++ b/gui/src/utils/__tests__/metricsParser.test.ts
@@ -1,0 +1,16 @@
+import parseMetrics from '../metricsParser';
+
+describe('parseMetrics', () => {
+  test('parses valid metrics', () => {
+    const text = '# comment\nrequests_total 5';
+    expect(parseMetrics(text)).toEqual([{ name: 'requests_total', value: 5 }]);
+  });
+
+  test('throws on malformed line', () => {
+    expect(() => parseMetrics('badline')).toThrow();
+  });
+
+  test('throws on invalid value', () => {
+    expect(() => parseMetrics('requests_total abc')).toThrow();
+  });
+});

--- a/gui/src/utils/metricsParser.ts
+++ b/gui/src/utils/metricsParser.ts
@@ -1,0 +1,26 @@
+export interface MetricPoint {
+  name: string;
+  value: number;
+}
+
+export default function parseMetrics(text: string): MetricPoint[] {
+  const counters: MetricPoint[] = [];
+  const lines = text.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length !== 2) {
+      throw new Error(`Invalid metric line: ${line}`);
+    }
+    const [key, val] = parts;
+    const num = parseFloat(val);
+    if (isNaN(num)) {
+      throw new Error(`Invalid metric value: ${line}`);
+    }
+    if (key.endsWith('_total')) {
+      counters.push({ name: key, value: num });
+    }
+  }
+  return counters;
+}


### PR DESCRIPTION
## Summary
- validate Prometheus metric lines with a new utility `parseMetrics`
- show a user friendly message when metrics parsing fails
- test invalid input for the parser and metrics component

## Testing
- `npm test --silent --prefix gui` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788b2f36948332be06f97b1effd7e5