### PR TITLE
Implement backend API calls in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,19 @@ Clone and manage repositories::
     python -m algorips repo commit "add feature"
     python -m algorips repo pr create --owner user --repo repo --token TOKEN "My PR"
     python -m algorips repo pr merge 1 --owner user --repo repo --token TOKEN
+
+## HTTP API Endpoints
+
+Repository operations are exposed by the Flask server:
+- `POST /repo/clone` with `{url, dest}`
+- `POST /repo/branch` with `{name}`
+- `POST /repo/commit` with `{message}`
+- `GET  /repo/pr` returns open pull requests
+- `POST /repo/pr/create` creates a pull request
+- `POST /repo/pr/merge` with `{number}` merges a PR
+
+Plugin management endpoints:
+- `GET  /plugins` returns installed plugins
+- `POST /plugins/install` with `{path}` installs a plugin
+- `DELETE /plugins/<name>` removes a plugin
+- Plugin documentation can be retrieved from `/plugins/<name>/README.md`

--- a/gui/src/__tests__/api.test.ts
+++ b/gui/src/__tests__/api.test.ts
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import {
+  cloneRepo,
+  createBranch,
+  commitChanges,
+  listPullRequests,
+  openPullRequest,
+  mergePullRequest,
+  listPlugins,
+  installPlugin,
+  uninstallPlugin,
+} from '../utils/api';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('cloneRepo posts to /repo/clone', async () => {
+  global.fetch = jest.fn().mockResolvedValue({} as any);
+  await cloneRepo('url', 'dest');
+  expect(fetch).toHaveBeenCalledWith('/repo/clone', expect.objectContaining({
+    method: 'POST',
+  }));
+});
+
+test('openPullRequest hits /repo/pr/create', async () => {
+  global.fetch = jest.fn().mockResolvedValue({} as any);
+  await openPullRequest();
+  expect(fetch).toHaveBeenCalledWith('/repo/pr/create', expect.objectContaining({ method: 'POST' }));
+});
+
+test('uninstallPlugin uses DELETE', async () => {
+  global.fetch = jest.fn().mockResolvedValue({} as any);
+  await uninstallPlugin('plug');
+  expect(fetch).toHaveBeenCalledWith('/plugins/plug', expect.objectContaining({ method: 'DELETE' }));
+});
+
+test('listPlugins returns data', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve([{ name: 'p' }]) } as any);
+  const data = await listPlugins();
+  expect(data[0].name).toBe('p');
+});

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -21,42 +21,62 @@ export async function saveSettings(cfg: Settings): Promise<void> {
 
 // Repository API stubs
 export async function cloneRepo(url: string, dest: string): Promise<void> {
-  console.log('cloneRepo', url, dest);
+  await fetch('/repo/clone', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, dest }),
+  });
 }
 
 export async function createBranch(name: string): Promise<void> {
-  console.log('createBranch', name);
+  await fetch('/repo/branch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
 }
 
 export async function commitChanges(msg: string): Promise<void> {
-  console.log('commitChanges', msg);
+  await fetch('/repo/commit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: msg }),
+  });
 }
 
 export async function listPullRequests(): Promise<any[]> {
-  console.log('listPullRequests');
-  return [];
+  const res = await fetch('/repo/pr');
+  return res.json();
 }
 
 export async function openPullRequest(): Promise<void> {
-  console.log('openPullRequest');
+  await fetch('/repo/pr/create', { method: 'POST' });
 }
 
 export async function mergePullRequest(num: number): Promise<void> {
-  console.log('mergePullRequest', num);
+  await fetch('/repo/pr/merge', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ number: num }),
+  });
 }
 
 // Plugin API stubs
 export async function listPlugins(): Promise<any[]> {
-  console.log('listPlugins');
-  return [];
+  const res = await fetch('/plugins');
+  return res.json();
 }
 
 export async function installPlugin(path: string): Promise<void> {
-  console.log('installPlugin', path);
+  await fetch('/plugins/install', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  });
 }
 
 export async function uninstallPlugin(name: string): Promise<void> {
-  console.log('uninstallPlugin', name);
+  await fetch(`/plugins/${name}`, { method: 'DELETE' });
 }
 
 // Database API


### PR DESCRIPTION
## Summary
- enable repository and plugin operations in `api.ts`
- document available HTTP endpoints
- test API calls through new Jest suite

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788b291cf88332a9550ea0f6120b89