### PR TITLE
Add model management for Ollama

### DIFF
--- a/algorips/cli/main.py
+++ b/algorips/cli/main.py
@@ -1,4 +1,7 @@
 import json
+import itertools
+import threading
+import time
 from pathlib import Path
 import subprocess
 
@@ -6,7 +9,8 @@ import click
 
 from algorips import __version__
 from algorips.core.analyzer import CodeAnalyzer
-from algorips.core import scraper
+from algorips.core import scraper, config as cfg
+from algorips.core.llm import OllamaProvider
 from algorips.core.git import local
 from algorips.core.git.github import GitHubClient
 from algorips.core.plugins import PluginManager
@@ -17,6 +21,9 @@ DEFAULT_CONFIG = (
     "  url: mysql+pymysql://root:example@localhost/algorips\n"
     "ollama_url: http://localhost:11434\n"
 )
+
+CONFIG = cfg.load()
+provider = OllamaProvider()
 
 
 @click.group()
@@ -67,6 +74,39 @@ def apply_rule(rule_id: str, file_path: str) -> None:
         click.echo("Patch applied")
     else:
         click.echo("Failed to apply patch")
+
+
+@cli.command()
+@click.argument("prompt", nargs=-1)
+@click.option("--model", default=None, help="Ollama model to use")
+def chat(prompt: tuple[str, ...], model: str | None) -> None:
+    """Send PROMPT to Ollama and print the response."""
+    mdl = model or CONFIG.get("model")
+    if not provider.model_exists(mdl):
+        click.echo(f"Model '{mdl}' not available", err=True)
+        raise click.Abort()
+    text = " ".join(prompt)
+
+    stop = threading.Event()
+
+    def spinner() -> None:
+        for ch in itertools.cycle("|/-\\"):
+            if stop.is_set():
+                break
+            click.echo(ch, nl=False)
+            click.echo("\b", nl=False)
+            time.sleep(0.1)
+
+    t = threading.Thread(target=spinner)
+    t.start()
+    try:
+        result = provider.send_prompt(text, mdl)
+    finally:
+        stop.set()
+        t.join()
+    click.echo(json.dumps(result, indent=2))
+    CONFIG["model"] = mdl
+    cfg.save(CONFIG)
 
 
 @cli.command("rag")
@@ -173,6 +213,35 @@ def pr_merge(pr_number: int, owner: str, repo_name: str, token: str) -> None:
 
 # Plugin commands
 plugin_manager = PluginManager()
+
+
+@cli.group()
+def models() -> None:
+    """Model related commands."""
+
+
+@models.command("ls")
+def models_ls() -> None:
+    """List available Ollama models."""
+    try:
+        for name in provider.list_models():
+            click.echo(name)
+    except Exception as exc:
+        click.echo(f"Failed to list models: {exc}", err=True)
+
+
+@cli.group()
+def ollama() -> None:
+    """Ollama helper commands."""
+
+
+@ollama.command("status")
+def ollama_status() -> None:
+    """Check if the Ollama server is reachable."""
+    if provider.health():
+        click.echo("Ollama is up")
+    else:
+        click.echo("Ollama is unreachable", err=True)
 
 
 @cli.group()

--- a/algorips/core/config.py
+++ b/algorips/core/config.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_DIR = Path.home() / ".algorips"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+DEFAULT_CONFIG: Dict[str, Any] = {"model": "llama3"}
+
+
+def load() -> Dict[str, Any]:
+    if CONFIG_FILE.exists():
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except Exception:
+            pass
+    return DEFAULT_CONFIG.copy()
+
+
+def save(cfg: Dict[str, Any]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2))

--- a/algorips/core/llm.py
+++ b/algorips/core/llm.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from typing import List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class LLMProvider(ABC):
+    """Abstract interface for language model providers."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    @abstractmethod
+    def list_models(self) -> List[str]:
+        """Return a list of available model names."""
+
+    @abstractmethod
+    def send_prompt(self, prompt: str, model: str) -> dict:
+        """Send *prompt* to *model* and return the JSON response."""
+
+    def health(self) -> bool:
+        try:
+            if hasattr(requests, "head"):
+                r = requests.head(self.base_url, timeout=3)
+                return getattr(r, "ok", False)
+            # fallback for stubbed requests
+            requests.post(self.base_url, timeout=3)
+            return True
+        except Exception:
+            return False
+
+
+class OllamaProvider(LLMProvider):
+    """LLMProvider implementation for Ollama."""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        super().__init__(base_url)
+
+    def list_models(self) -> List[str]:
+        url = f"{self.base_url}/api/tags"
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        return [m.get("name") for m in data.get("models", [])]
+
+    def model_exists(self, name: str) -> bool:
+        try:
+            return name in self.list_models()
+        except Exception:
+            return False
+
+    def send_prompt(self, prompt: str, model: str) -> dict:
+        url = f"{self.base_url}/v1/chat/completions"
+        payload = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+        backoff = 1.0
+        for _ in range(3):
+            start = time.time()
+            try:
+                logger.info("sending prompt at %s", start)
+                resp = requests.post(url, json=payload, timeout=10)
+                resp.raise_for_status()
+                logger.info("received response at %s", time.time())
+                return resp.json()
+            except requests.Timeout:
+                logger.warning("timeout talking to Ollama, retrying")
+                time.sleep(backoff)
+                backoff *= 2
+        raise RuntimeError("failed to communicate with Ollama")

--- a/algorips/tests/test_llm_provider.py
+++ b/algorips/tests/test_llm_provider.py
@@ -1,0 +1,25 @@
+from algorips.core.llm import OllamaProvider
+
+
+def test_send_prompt(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, timeout=10):
+        calls['url'] = url
+        calls['json'] = json
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'answer': '42'}
+        return R()
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    provider = OllamaProvider('http://x')
+
+    monkeypatch.setattr(provider, 'list_models', lambda: ['foo'])
+    assert provider.model_exists('foo')
+    result = provider.send_prompt('hi', 'foo')
+    assert result['answer'] == '42'
+    assert calls['json']['model'] == 'foo'


### PR DESCRIPTION
## Summary
- add configurable model provider
- add `chat` command with spinner and model flag
- list local models with `models ls`
- check Ollama health via `ollama status`
- persist last used model in `~/.algorips/config.json`
- cover provider logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68788b78afa4833280a98daf6e59d362