### PR TITLE
Improve sidebar responsiveness

### DIFF
--- a/gui/src/__tests__/Sidebar.test.tsx
+++ b/gui/src/__tests__/Sidebar.test.tsx
@@ -8,3 +8,10 @@ test('renders sidebar', () => {
   expect(getByText('Análisis')).toBeInTheDocument();
   expect(getByText('Chat')).toBeInTheDocument();
 });
+
+test('applies responsive width classes', () => {
+  const { getByLabelText } = render(<Sidebar />);
+  const nav = getByLabelText('Sidebar');
+  expect(nav).toHaveClass('md:w-60');
+  expect(nav).toHaveClass('lg:w-72');
+});

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -14,7 +14,10 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ active }) => (
-  <nav className="h-full bg-surface border-r border-gray-200 p-4 hidden md:block" aria-label="Sidebar">
+  <nav
+    className="h-full bg-surface border-r border-gray-200 p-4 hidden md:block md:w-60 lg:w-72"
+    aria-label="Sidebar"
+  >
     <ul className="space-y-4">
       {items.map(({ icon: Icon, label }) => (
         <li key={label} className={label === active ? 'text-primary font-semibold' : ''}>

--- a/gui/src/layouts/Layout.tsx
+++ b/gui/src/layouts/Layout.tsx
@@ -6,7 +6,7 @@ import Footer from '../components/Footer';
 const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [open, setOpen] = useState(false);
   return (
-    <div className="min-h-screen grid md:grid-cols-[240px_1fr]">
+    <div className="min-h-screen md:grid md:grid-cols-[auto_1fr]">
       <Sidebar active="Dashboard" />
       <button
         className="md:hidden p-2 m-2 rounded bg-primary text-white"


### PR DESCRIPTION
## Summary
- adjust sidebar navigation to use responsive Tailwind widths
- update layout to rely on width classes rather than a fixed column
- test sidebar responsive classes

## Testing
- `pytest -q`
- `npm --prefix gui test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788b280fd88332bea40bfb291eee08