### PR TITLE
Improve plugin validation and tests

### DIFF
--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 
 from algorips.core.plugins.manager import PluginManager
 from algorips.core.plugins.contract import BasePlugin
@@ -27,13 +28,34 @@ class DummyPlugin(BasePlugin):
         return []
 
 
+class MissingRegisterPlugin:
+    def name(self) -> str:
+        return "bad"
+
+    def version(self) -> str:
+        return "0.1"
+
+
+class FailingRegisterPlugin(BasePlugin):
+    def name(self) -> str:
+        return "failreg"
+
+    def version(self) -> str:
+        return "0.1"
+
+    def register(self, cli, gui_registry) -> None:
+        raise RuntimeError("boom")
+
+
 def create_plugin(path: Path) -> None:
-    pkg = path / "dummy"
+    create_custom_plugin(path, "dummy", "DummyPlugin")
+
+
+def create_custom_plugin(path: Path, pkg_name: str, cls_name: str) -> None:
+    pkg = path / pkg_name
     pkg.mkdir(parents=True, exist_ok=True)
     init = pkg / "__init__.py"
-    init.write_text(
-        "from tests.test_plugin_manager import DummyPlugin as Plugin\n"
-    )
+    init.write_text(f"from tests.test_plugin_manager import {cls_name} as Plugin\n")
 
 
 def test_discover(tmp_path: Path):
@@ -102,3 +124,22 @@ def test_entry_point_loading(tmp_path: Path, monkeypatch):
     mgr = PluginManager(plugin_dir=tmp_path)
     plugins = mgr.discover()
     assert "dummy" in plugins
+
+
+def test_missing_methods(tmp_path: Path, caplog):
+    create_custom_plugin(tmp_path, "bad", "MissingRegisterPlugin")
+    mgr = PluginManager(plugin_dir=tmp_path)
+    with caplog.at_level(logging.WARNING):
+        plugins = mgr.discover()
+        assert "bad" not in plugins
+    assert "missing required methods" in caplog.text
+
+
+def test_register_failure(tmp_path: Path, caplog):
+    create_custom_plugin(tmp_path, "failreg", "FailingRegisterPlugin")
+    mgr = PluginManager(plugin_dir=tmp_path)
+    mgr.discover()
+    with caplog.at_level(logging.WARNING):
+        mgr.activate("failreg")
+        assert "failreg" not in mgr._active
+    assert "failed to register" in caplog.text


### PR DESCRIPTION
## Summary
- verify plugin implementations in `PluginManager`
- handle registration failures gracefully
- test with invalid plugins

## Testing
- `pytest tests/test_plugin_manager.py::test_missing_methods -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68788b2d2e5c8332818649a0177f5f93