### PR TITLE
Implement chat history support

### DIFF
--- a/algorips/core/conversations.py
+++ b/algorips/core/conversations.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+from sqlalchemy import text
+
+from .db import get_session
+
+
+def save(prompt: str, response: str) -> None:
+    """Persist prompt and response in the conversations table."""
+    with get_session() as session:
+        session.execute(
+            text("INSERT INTO conversations (prompt, response) VALUES (:p, :r)"),
+            {"p": prompt, "r": response},
+        )
+        session.commit()
+
+
+def delete(conv_id: Optional[int] = None) -> None:
+    """Delete a conversation by ID or all if ID is None."""
+    with get_session() as session:
+        if conv_id is None:
+            session.execute(text("DELETE FROM conversations"))
+        else:
+            session.execute(
+                text("DELETE FROM conversations WHERE id=:id"),
+                {"id": conv_id},
+            )
+        session.commit()
+
+
+def list_all() -> List[Dict[str, object]]:
+    """Return all conversations ordered by ID."""
+    with get_session() as session:
+        result = session.execute(
+            text("SELECT id, prompt, response, timestamp FROM conversations ORDER BY id")
+        ).mappings()
+        return [dict(row) for row in result]

--- a/algorips/core/ollama_client.py
+++ b/algorips/core/ollama_client.py
@@ -10,23 +10,54 @@ class OllamaClient:
     """Simple client to interact with an Ollama server."""
 
     def __init__(
-        self, host: str | None = None, port: int | None = None, model: str | None = None
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        model: str | None = None,
+        *,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         url = os.getenv("OLLAMA_URL", "http://localhost:11434")
         parsed = urlparse(url)
         self.host = host or parsed.hostname or "localhost"
         self.port = port or parsed.port or 11434
         self.model = model or os.getenv("OLLAMA_MODEL", "llama3")
+        self.temperature = float(os.getenv("OLLAMA_TEMPERATURE", "0.7")) if temperature is None else temperature
+        self.top_p = float(os.getenv("OLLAMA_TOP_P", "0.9")) if top_p is None else top_p
+        self.max_tokens = int(os.getenv("OLLAMA_MAX_TOKENS", "1024")) if max_tokens is None else max_tokens
         self.base_url = f"http://{self.host}:{self.port}"
 
     def set_model(self, model: str) -> None:
         """Change the target MODEL used for completions."""
         self.model = model
 
+    def set_params(
+        self,
+        *,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
+        """Update generation parameters used for completions."""
+        if temperature is not None:
+            self.temperature = temperature
+        if top_p is not None:
+            self.top_p = top_p
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
+
     def send_prompt(self, prompt: str) -> dict:
         """Send PROMPT to the completions endpoint and return the JSON response."""
         url = f"{self.base_url}/v1/completions"
-        payload = {"prompt": prompt, "model": self.model}
+        payload = {
+            "prompt": prompt,
+            "model": self.model,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_tokens": self.max_tokens,
+        }
         response = requests.post(url, json=payload)
         response.raise_for_status()
         return response.json()

--- a/algorips/core/server.py
+++ b/algorips/core/server.py
@@ -4,6 +4,7 @@ import time
 from .analyzer import CodeAnalyzer
 from .db_connector import execute_query
 from .ollama_client import OllamaClient
+from .conversations import save as save_conversation, delete as delete_conversation, list_all
 
 app = Flask(__name__)
 REQUESTS = Counter('algorips_requests_total', 'Total requests')
@@ -39,10 +40,33 @@ def chat_route():
     data = request.get_json() or {}
     prompt = data.get('prompt', '')
     model = data.get('model')
+    temperature = data.get('temperature')
+    top_p = data.get('top_p')
+    max_tokens = data.get('max_tokens')
     if model:
         client.set_model(model)
+    client.set_params(
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+    )
     result = client.send_prompt(prompt)
+    save_conversation(prompt, result['choices'][0]['text'] if 'choices' in result else str(result))
     return jsonify(result)
+
+
+@app.route('/history', methods=['GET'])
+def history_route():
+    """Return conversation history."""
+    return jsonify(list_all())
+
+
+@app.route('/history/<int:conv_id>', methods=['DELETE'])
+@app.route('/history', methods=['DELETE'])
+def delete_history_route(conv_id: int | None = None):
+    """Delete a conversation by ID or all if no ID provided."""
+    delete_conversation(conv_id)
+    return jsonify({'status': 'ok'})
 
 
 @app.route('/db/query', methods=['POST'])

--- a/db/migrations/0003_create_conversations_table.sql
+++ b/db/migrations/0003_create_conversations_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS conversations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    response TEXT NOT NULL,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add conversation persistence utilities
- extend Ollama client with generation parameters
- store chat history and expose history endpoints
- add migration for conversation table
- test new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687986e8119083328cfe15512562caad