### PR TITLE
Improve responsive design

### DIFF
--- a/gui/src/features/analyze/Analyze.tsx
+++ b/gui/src/features/analyze/Analyze.tsx
@@ -15,8 +15,8 @@ const Analyze: React.FC = () => {
 
   if (loading) return <Spinner />;
   return (
-    <div>
-      <h2>Analysis</h2>
+    <div className="space-y-4 max-w-5xl mx-auto">
+      <h2 className="text-lg font-semibold">Analysis</h2>
       <Card>
         <LineChart width={400} height={200} data={data} aria-label="Metrics chart">
           <XAxis dataKey="name" />

--- a/gui/src/features/chat/Chat.tsx
+++ b/gui/src/features/chat/Chat.tsx
@@ -127,7 +127,7 @@ const Chat: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-full border rounded-2xl shadow-lg">
+    <div className="flex flex-col h-full border rounded-2xl shadow-lg bg-surface max-w-3xl mx-auto">
       <div className="flex-1 overflow-y-auto p-4 space-y-4" aria-label="messages">
         {messages.map((m, idx) => (
           <div key={idx} className="flex items-start gap-2" aria-label="message">
@@ -140,7 +140,7 @@ const Chat: React.FC = () => {
         ))}
         <div ref={endRef} />
       </div>
-      <div className="p-2 flex items-center gap-2 border-t">
+      <div className="p-2 flex flex-wrap items-center gap-2 border-t">
         <input
           aria-label="prompt"
           value={input}

--- a/gui/src/features/dashboard/Dashboard.tsx
+++ b/gui/src/features/dashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ const metrics = [
 ];
 
 const Dashboard: React.FC = () => (
-  <div className="p-4 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+  <div className="grid gap-6 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 max-w-5xl mx-auto">
     {metrics.map((m, idx) => (
       <div key={idx} className="rounded-2xl shadow-lg bg-surface p-4 flex items-center space-x-4">
         {m.icon}

--- a/gui/src/features/diffs/Diffs.tsx
+++ b/gui/src/features/diffs/Diffs.tsx
@@ -13,8 +13,8 @@ const Diffs: React.FC = () => {
 
   if (loading) return <Spinner />;
   return (
-    <div>
-      <h2>Diffs</h2>
+    <div className="space-y-4 max-w-5xl mx-auto">
+      <h2 className="text-lg font-semibold">Diffs</h2>
       {diffs.map((d, idx) => (
         <Card key={idx}>{(d as any).path}</Card>
       ))}

--- a/gui/src/features/home/Home.tsx
+++ b/gui/src/features/home/Home.tsx
@@ -9,7 +9,7 @@ const Home: React.FC = () => {
   };
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-6 max-w-lg mx-auto bg-surface rounded-xl shadow space-y-4">
       <h2 className="text-xl font-semibold">Choose project directory</h2>
       <label htmlFor="project-path" className="sr-only">Project path</label>
       <input

--- a/gui/src/features/metrics/Metrics.tsx
+++ b/gui/src/features/metrics/Metrics.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts';
 import parseMetrics, { MetricPoint } from '../../utils/metricsParser';
 
 const Metrics: React.FC = () => {
@@ -26,20 +26,24 @@ const Metrics: React.FC = () => {
   }, []);
 
   return (
-    <div>
-      <h2>Metrics</h2>
+    <div className="space-y-4 max-w-5xl mx-auto">
+      <h2 className="text-lg font-semibold">Metrics</h2>
       {error && (
         <div role="alert" style={{ color: 'red' }}>
           {error}
         </div>
       )}
-      <LineChart width={400} height={200} data={data} aria-label="Metrics chart">
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="name" />
-        <YAxis allowDecimals={false} />
-        <Tooltip />
-        <Line type="monotone" dataKey="value" stroke="#8884d8" />
-      </LineChart>
+      <div className="w-full h-60">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} aria-label="Metrics chart">
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Line type="monotone" dataKey="value" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/gui/src/features/plugins/Plugins.tsx
+++ b/gui/src/features/plugins/Plugins.tsx
@@ -35,24 +35,29 @@ const Plugins: React.FC = () => {
 
   if (loading) return <Spinner />;
   return (
-    <div>
-      <h2>Plugins</h2>
-      <div>
+    <div className="space-y-4 max-w-3xl mx-auto">
+      <h2 className="text-lg font-semibold">Plugins</h2>
+      <div className="flex items-center gap-2">
         <input
           value={path}
           onChange={e => setPath(e.target.value)}
           placeholder="plugin path"
+          className="border rounded p-2 flex-1"
         />
-        <button onClick={onInstall}>Install</button>
+        <button className="px-4 py-2 rounded bg-primary text-white" onClick={onInstall}>Install</button>
       </div>
-      <ul>
+      <ul className="divide-y">
         {plugins.map(p => (
-          <li key={p.name}>
-            {p.name} {p.version}{' '}
-            <button onClick={() => onUninstall(p.name)}>Uninstall</button>{' '}
-            <button onClick={() => window.open(`/plugins/${p.name}/README.md`)}>
-              View docs
-            </button>
+          <li key={p.name} className="py-1 flex items-center justify-between">
+            <span>
+              {p.name} {p.version}{' '}
+            </span>
+            <div className="flex gap-2">
+              <button className="text-primary" onClick={() => onUninstall(p.name)}>Uninstall</button>{' '}
+              <button className="text-primary" onClick={() => window.open(`/plugins/${p.name}/README.md`)}>
+                View docs
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/gui/src/features/repository/Repository.tsx
+++ b/gui/src/features/repository/Repository.tsx
@@ -19,19 +19,27 @@ const Repository: React.FC = () => {
   }, []);
 
   return (
-    <div>
-      <h2>Repository</h2>
-      <div>
-        <input value={url} onChange={e => setUrl(e.target.value)} placeholder="repo url" />
-        <button onClick={handleClone}>Clone</button>
+    <div className="space-y-4 max-w-5xl mx-auto">
+      <h2 className="text-lg font-semibold">Repository</h2>
+      <div className="flex items-center gap-2">
+        <input
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="repo url"
+          className="border rounded p-2 flex-1"
+        />
+        <button className="px-4 py-2 rounded bg-primary text-white" onClick={handleClone}>Clone</button>
       </div>
-      <button onClick={() => createBranch('feature')}>New Branch</button>
-      <button onClick={() => commitChanges('update')}>Commit</button>
-      <button onClick={openPullRequest}>Open PR</button>
-      <ul>
+      <div className="flex flex-wrap gap-2">
+        <button className="px-3 py-1 rounded bg-primary text-white" onClick={() => createBranch('feature')}>New Branch</button>
+        <button className="px-3 py-1 rounded bg-primary text-white" onClick={() => commitChanges('update')}>Commit</button>
+        <button className="px-3 py-1 rounded bg-primary text-white" onClick={openPullRequest}>Open PR</button>
+      </div>
+      <ul className="divide-y">
         {prs.map(pr => (
-          <li key={pr.number}>
-            PR #{pr.number} <button onClick={() => mergePullRequest(pr.number)}>Merge</button>
+          <li key={pr.number} className="py-1 flex items-center justify-between">
+            <span>PR #{pr.number}</span>
+            <button className="text-primary" onClick={() => mergePullRequest(pr.number)}>Merge</button>
           </li>
         ))}
       </ul>

--- a/gui/src/features/settings/Settings.tsx
+++ b/gui/src/features/settings/Settings.tsx
@@ -18,9 +18,15 @@ const SettingsPage: React.FC = () => {
   };
 
   return (
-    <form onSubmit={onSubmit} aria-label="Settings form">
-      <input name="example" onChange={onChange} value={(local as any).example || ''} aria-label="Example setting" />
-      <button type="submit">Save</button>
+    <form onSubmit={onSubmit} aria-label="Settings form" className="space-y-4 max-w-md mx-auto">
+      <input
+        name="example"
+        onChange={onChange}
+        value={(local as any).example || ''}
+        aria-label="Example setting"
+        className="border rounded p-2 w-full"
+      />
+      <button type="submit" className="px-4 py-2 rounded bg-primary text-white">Save</button>
     </form>
   );
 };

--- a/gui/src/features/tests/Tests.tsx
+++ b/gui/src/features/tests/Tests.tsx
@@ -13,8 +13,8 @@ const Tests: React.FC = () => {
 
   if (loading) return <Spinner />;
   return (
-    <div>
-      <h2>Tests</h2>
+    <div className="space-y-4 max-w-5xl mx-auto">
+      <h2 className="text-lg font-semibold">Tests</h2>
       <Card>{report ? JSON.stringify(report) : 'No report'}</Card>
     </div>
   );

--- a/gui/src/layouts/Layout.tsx
+++ b/gui/src/layouts/Layout.tsx
@@ -22,7 +22,9 @@ const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
       )}
       <main className="flex flex-col">
         <Header />
-        <div className="flex-1">{children}</div>
+        <div className="flex-1 container mx-auto p-4 md:p-8 space-y-12">
+          {children}
+        </div>
         <Footer />
       </main>
     </div>

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -4,6 +4,6 @@
 
 @layer base {
   body {
-    @apply bg-bg text-text font-sans;
+    @apply bg-bg text-text font-sans min-h-screen;
   }
 }


### PR DESCRIPTION
## Summary
- refine Layout container spacing
- style home screen card
- balance Dashboard grid
- improve Analyze, Diffs, Repository, Tests, Metrics, Plugins UIs
- enhance Chat layout
- tweak settings form and base styles

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68798a11070483328db5f64ba09d76b7